### PR TITLE
Mac Pipeline build AU as not-synth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .DS_Store
 build/
+buildwin/
+buildlin/
 build32/
 .vscode/
 build.install/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,7 +133,11 @@ target_compile_definitions(stochas
     JUCE_WEB_BROWSER=0  # If you remove this, add `NEEDS_WEB_BROWSER TRUE` to the `juce_add_plugin` call
     JUCE_USE_CURL=0     # If you remove this, add `NEEDS_CURL TRUE` to the `juce_add_plugin` call
     JUCE_VST3_CAN_REPLACE_VST2=0
- 
+
+    # GPL3 Plugs can disable splash screen
+    JUCE_DISPLAY_SPLASH_SCREEN=0
+    JUCE_REPORT_APP_USAGE=0
+
     # Some linux options
     JUCE_JACK=1
     JUCE_ALSA=1
@@ -228,4 +232,18 @@ else()
              -Force
              -Path "${ZIP_FROM_DIR}"
     )
+endif()
+
+if( APPLE )
+  add_custom_target( install-au-local )
+  add_dependencies( install-au-local stochas_AU )
+  add_custom_command(
+    TARGET install-au-local
+    POST_BUILD
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND echo "Installing audio unit locally"
+    COMMAND rsync -r --delete "${ZIP_FROM_DIR}/AU/Stochas.component/" "\${HOME}/Library/Audio/Plug-Ins/Components/Stochas.component/"
+    COMMAND auval -vt aumi AuVi
+    )
+
 endif()

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ By default AAX is not built, but if you have the AAX sdk you will be able to ena
 - If you want to set a particular version add -DSTOCHAS_VERSION=9.9.9 in options below otherwise the version will be 0.9.0 
 - VST2 - if you need it you need to add -DVST2_PATH=path-to-vst2-sdk-here to options below
 - AAX - if you need it you need to install the sdk and edit the CMakefile
+- AU - if you are building the AudioUnit add the option -DSTOCHAS_IS_SYNTH=FALSE
 - Build Stochas:
   - git submodule update --init --recursive
   - cmake -B build [options]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -75,8 +75,24 @@ jobs:
 
 
   - bash: |
+      # For now we expand this out so we can swap the STOCHAS_IS_SYNTH flag for the AU off
       cmake -Bbuild -GXcode
-      cmake --build build --config Release --target installer-pkg
+      cmake --build build --target stochas_VST3 --config Release | xcpretty
+      cmake --build build --target stochas_Standalone --config Release | xcpretty
+
+      mkdir build/tmpasset
+      mv build/stochas_artefacts/Release/VST3 build/tmpasset
+      mv build/stochas_artefacts/Release/Standalone build/tmpasset
+
+      cmake -Bbuild -DSTOCHAS_IS_SYNTH=FALSE
+      cmake --build build --target stochas_AU --config Release | xcpretty
+      mv build/stochas_artefacts/Release/AU build/tmpasset
+
+      GH=`git log -1 --format=%h`
+      NM=stochas-${GH}-mac.dmg
+
+      mkdir build/product/
+      hdiutil create build/product/${NM} -ov -volname "Stochas ${GH}" -fs HFS+ -srcfolder build/tmpasset
     displayName: Build Mac
     condition: variables.isMac
 


### PR DESCRIPTION
Modify the Mac pipeline so the IS_SYNTH is false and we
still get a single installer. Update the README. Add an
install-local-au convenience target to CMake for mac.
Disable the JUCE splash since we are GPL3.

Addresses #7