### PR TITLE
Fix for Cantabile loading saved Stochas state

### DIFF
--- a/src/EditorState.h
+++ b/src/EditorState.h
@@ -198,7 +198,6 @@ class SeqAudioProcessor;
 // TODO not sure if it really belongs here
 class SeqGlob {
 public:
-   void *mAlertListener;
    EditorState *mEditorState;
    SeqDataBuffer *mSeqBuf;
    SeqProcessorNotifier *mAudNotify;
@@ -223,6 +222,10 @@ public:
    {
       // tell it to call changeNotify when some data changes
       mSeqBuf->setChangeNotify(changeNotify, this);
+   }
+
+   ~SeqGlob() {
+      mSeqBuf->setChangeNotify(0,0);
    }
 
 };


### PR DESCRIPTION
It looks like Cantabile fires up the plugin editor, then destroys it
before loading the saved project. There is a notifier callback that the
plugin calls that is owned by the editor. since it was destroyed the
callback object became invalid. solution is to clear the notifier when
the plugin editor is destroyed so that it doesn't call it.