### PR TITLE
Changes char to int8_t [#74]

### DIFF
--- a/src/NotePanel.cpp
+++ b/src/NotePanel.cpp
@@ -348,7 +348,7 @@ void NotePanel::mouseDrag(const MouseEvent & event)
          // clamp to 127
          newval = mMouseStartVal + mouseDist;
          newval = newval > 127 ? 127 : newval < 0 ? 0 : newval;
-         c->mTempValue = (char)newval;
+         c->mTempValue = (int8_t)newval;
          repaint();
       }
    }

--- a/src/StepPanel.cpp
+++ b/src/StepPanel.cpp
@@ -516,7 +516,7 @@ StepPanel::mouseDrag(const MouseEvent &event)
 
                // write to a temporary value on the step itself. This will be written to seq on mouseUp
                // also used during paint
-               c->mTempValue = (char)newval;
+               c->mTempValue = (int8_t)newval;
             } 
             repaint();
          }

--- a/src/StepPanel.h
+++ b/src/StepPanel.h
@@ -26,7 +26,7 @@ public:
    int mCol;
    SeqGlob *mGlob;
    // if we are in the act of dragging, this will hold the temporary value (otherwise -1)
-   char mTempValue;
+   int8_t mTempValue;
    StepCpt();
    void paint(Graphics &g) override;
    // determine the color of the cell and the text content
@@ -131,7 +131,7 @@ class StepPanel : public Component, public KeyListener {
 
    // this keeps track of original value when mouse down event first happens
    // will be -99 if nothings going on
-   char mMouseStartVal;
+   int8_t mMouseStartVal;
 
    // keep track of starting item for chain drag
    StepCpt *mChainStartItem;


### PR DESCRIPTION
Stochas does not work on the raspberry pi (and probably other arm devices) because `char` is not signed on arm devices. Changing two variable from `char` to `int8_t` seems to have solved Stochas from having weird behavior on the Raspberry Pi (issue #74)