### PR TITLE
Fix looped playback extra note trigger

### DIFF
--- a/src/CommonComponents.cpp
+++ b/src/CommonComponents.cpp
@@ -11,22 +11,6 @@
 #include "CommonComponents.h"
 #include "NotePanel.h"
 
-// this is temporary
-void
-logMessage(String msg)
-{
-   std::unique_ptr<FileOutputStream> os;
-   String fn;
-   File dir = File::getSpecialLocation(File::currentExecutableFile);
-   fn = dir.getFullPathName();
-   fn.append(".log", 0xFF);
-   os = File(fn).createOutputStream();
-   if (os != nullptr) {
-      msg += "\n";
-      os->writeText(msg, false, false,0);
-   }
-}
-
 
 
 /*===========================================================================================

--- a/src/PluginEditor.h
+++ b/src/PluginEditor.h
@@ -194,7 +194,4 @@ private:
 };
 
 
-// todo remove this at some point
-void logMessage(String msg);
-
 #endif  // PLUGINEDITOR_H_INCLUDED


### PR DESCRIPTION
Two things were done to fix this. Firstly when determining whether a step needs to play
in the current sample block, subtract one from sample block size to account for any
rounding issue that may have occurred when adding the step to the queue. This should not
affect normal playback (non looped) even if it means we treat the step as occurring in the
next sample block, because on the following block it will always get picked up and sent.
Secondly: as a result of the first fix a new issue appears sometimes where the first step
of subsequent loops fails to be sent. (eg in reaper with sample block size 512 and tempo
120.1, loop bar 1 or 3 and it will not send step 1 on subsequent loops).
This is solved by rounding the play position when first starting a loop. this causes it
to pick up a step that may have occurred as far as half a step in the past.
(rounds to int so if we are over 0.5 on a step it plays next step otherwise
it plays previous step). ie it may play a step which would have occurred in the past up
to 1/2 a step ago. to demo, set reaper to 1/32 grid and set loop to 1 bar, move left loop
pointer 1/32 to the right. in this case it will now play that first step even though its
looping back to 1/32 after the top of the bar.
what we are trying to solve here is for the case where the sample block that played at
the very end of the bar before it loops actually extended far enough past the end of the bar
that the next sample block that comes in has a position that is actually after the
beginning of the bar.