### PR TITLE
Allow Scale Factor for UI < 100

### DIFF
--- a/src/Constants.h
+++ b/src/Constants.h
@@ -80,7 +80,7 @@ in mono mode are 0..high val where 0 is off, and the following applies
 
 // ui scaling
 #define SEQ_UI_SCALE_DEFAULT  100
-#define SEQ_UI_SCALE_MIN      100
+#define SEQ_UI_SCALE_MIN      50
 #define SEQ_UI_SCALE_MAX      200
 
 // duty cycle in % (101 is legato)


### PR DESCRIPTION
Range was 100-200; but folks with very old systems and small monitors
had a desire for at least <100 in reaper and other hosts. So make
the range 50-200.

There's other zoom and size problems but this at least lets you get
there witha config edit